### PR TITLE
Use the class web_delay property instead of hard coded value to reset the web cooldown

### DIFF
--- a/lotsqrl/actors/spiders.py
+++ b/lotsqrl/actors/spiders.py
@@ -238,7 +238,7 @@ class SpiderQueen(Arachnid):
 
         if self.score is not None:
             self.score.webs_fired += 1
-        self.web_cooldown = 20
+        self.web_cooldown = self.web_delay
 
         for i in range(10):
             web_x, web_y = self.x + (offset[0] * i), self.y + (offset[1] * i)


### PR DESCRIPTION
The value was hard coded. I modified the code to use the value defined in the class instead.