### PR TITLE
CombatLog Scope

### DIFF
--- a/lotsqrl/actions/base.py
+++ b/lotsqrl/actions/base.py
@@ -27,12 +27,12 @@ class Action(object):
         :rtype bool:
         """
         if target is None:
-            actor.game.player_message(actor, "No enemy there.")
+            actor.game.messaging.add_player_message("No enemy there.", actor)
             return False
         
         cooldown = actor.cooldowns.get(self.name)
         if cooldown:
-            actor.game.player_message(actor, "You need to wait %s more rounds." % cooldown)
+            actor.game.messaging.add_player_message(f"You need to wait {cooldown} more rounds.", actor)
             return False
         return True
 

--- a/lotsqrl/actions/goblins.py
+++ b/lotsqrl/actions/goblins.py
@@ -1,4 +1,5 @@
 from lotsqrl.actions.base import MeleeAttack
+from lotsqrl.messages import MessageScope
 
 
 class Stab(MeleeAttack):
@@ -7,7 +8,12 @@ class Stab(MeleeAttack):
 
     def on_hit(self, actor, target):
         game = actor.game
-        game.add_message(actor.name + " stabs %s!" % target.name)
+        game.messaging.add_scoped_message(
+            message_actor=f"You stab {target.name}!",
+            message_target=f"{actor.name} stabs you!",
+            message_others=f"{actor.name} stabs {target.name}!",
+            actor=actor, target=target, scope=MessageScope.TargetsPlayer
+        )
         super().on_hit(actor, target)
 
 
@@ -23,7 +29,12 @@ class Headbutt(MeleeAttack):
 
     def on_hit(self, actor, target):
         game = actor.game
-        game.add_message(actor.name + " headbutts %s!" % target.name)
+        game.messaging.add_scoped_message(
+            message_actor=f"You headbutt {target.name}!",
+            message_target=f"{actor.name} headbutts you!",
+            message_others=f"{actor.name} headbutts {target.name}!",
+            actor=actor, target=target, scope=MessageScope.TargetsPlayer
+        )
         super().on_hit(actor, target)
         self.apply_cooldown(actor)
         target.stunned = True
@@ -35,5 +46,10 @@ class Slice(MeleeAttack):
 
     def on_hit(self, actor, target):
         game = actor.game
-        game.add_message(actor.name + " slices %s!" % target.name)
+        game.messaging.add_scoped_message(
+            message_actor=f"You slice {target.name}!",
+            message_target=f"{actor.name} slices you!",
+            message_others=f"{actor.name} slices {target.name}!",
+            actor=actor, target=target, scope=MessageScope.TargetsPlayer
+        )
         super().on_hit(actor, target)

--- a/lotsqrl/actions/spiders.py
+++ b/lotsqrl/actions/spiders.py
@@ -15,7 +15,7 @@ class Bite(MeleeAttack):
         game.messaging.add_scoped_message(
             message_actor=f"You bite {target.name}!",
             message_target=f"{actor.name} bites you!",
-            message_others=f"{target.name} bites {actor.name}!",
+            message_others=f"{actor.name} bites {target.name}!",
             scope=MessageScope.TargetsPlayer,
             actor=actor, target=target
         )

--- a/lotsqrl/actors/base.py
+++ b/lotsqrl/actors/base.py
@@ -1,5 +1,6 @@
 from lotsqrl import components, controllers
 from lotsqrl.gameobjects import GameObject, Corpse
+from lotsqrl.messages import MessageScope
 
 
 class Actor(GameObject):
@@ -36,10 +37,12 @@ class Actor(GameObject):
         self.dead = True
         self.display_char = "%"
         self.display_priority = 10
-        if self.is_player:
-            self.game.add_message("You are dead!")
-        else:
-            self.game.add_message(self.name + " is dead!")
+        self.game.messaging.add_scoped_message(
+            message_actor="You are dead!",
+            message_others=f"{self.name} is dead!",
+            scope=MessageScope.TargetsPlayer,
+            actor=self
+        )
         corpse = Corpse(self.game, self.name, self.x, self.y)
         self.game.level.remove_actor(self)
         self.game.level.add_actor(corpse)

--- a/lotsqrl/actors/goblins.py
+++ b/lotsqrl/actors/goblins.py
@@ -60,3 +60,7 @@ class GoblinChief(Actor):
         if self.headbutt_cooldown == 0:
             return self.actions.try_execute("headbutt", target)
         return self.actions.try_execute("slice", target)
+
+    def on_death(self):
+        self.game.messaging.add_system_message("The boss has been killed!")
+        super().on_death()

--- a/lotsqrl/components/actions.py
+++ b/lotsqrl/components/actions.py
@@ -48,7 +48,7 @@ class Action(object):
                 for selector in action.selectors:
                     result = selector.get(self.host)
                     if result is terminal.TK_INPUT_CANCELLED:
-                        self.host.game.add_message("Cancelled.")
+                        self.host.game.messaging.add_system_message("Cancelled.")
                         return False
                     else:
                         targets.extend(result)

--- a/lotsqrl/config.py
+++ b/lotsqrl/config.py
@@ -43,6 +43,7 @@ class MainOptions(ConfigurableOptions):
         OptionField('graphical_tiles', True, parse_bool),
         OptionField('map_width', 25, int),
         OptionField('map_height', 25, int),
+        OptionField('msg_scope', 0, int),
     )
 
 

--- a/lotsqrl/game.py
+++ b/lotsqrl/game.py
@@ -7,6 +7,7 @@ from lotsqrl import actors, automata, controllers, tiles
 from lotsqrl.camera import Camera
 from lotsqrl.scenes.game import GameScene
 from lotsqrl.teams import Team
+from lotsqrl.messages import Messaging
 
 
 class Game(object):
@@ -18,22 +19,12 @@ class Game(object):
         self.game_won = False
         self.options = options
         self.screen_info = screen_info
-        self.messages = []
         self.level = None
         self.running = False
         self.should_restart = False
         self.scene = GameScene(self, screen_info)
         self.turn = 0
-
-    def add_message(self, message, show_now=False):
-        self.messages.append(message)
-        if show_now:
-            self.scene.update_messages()
-            terminal.refresh()
-
-    def player_message(self, actor, message, show_now=False):
-        if actor.is_player:
-            self.add_message(message, show_now)
+        self.messaging = Messaging(self, self.options.msg_scope)
 
     def prepare(self):
         automata_steps = 4  # Usually gives a nice layout

--- a/lotsqrl/movement.py
+++ b/lotsqrl/movement.py
@@ -6,6 +6,7 @@ from pathfinding.core.grid import Grid
 from pathfinding.finder.a_star import AStarFinder
 
 from lotsqrl import tiles, utils
+from lotsqrl.messages import MessageScope
 
 
 def avoid_obstacle(actor, target, offset_x, offset_y):
@@ -128,7 +129,11 @@ def step_to_target(actor, target):
         return success
     else:
         actor.level.remove_tile(tx, ty)
-        actor.game.add_message(actor.name + " digs through rock.")
+        actor.game.messaging.add_scoped_message(
+            message_others=actor.name + " digs through rock.",
+            scope=MessageScope.All,
+            actor=actor
+        )
         return True
 
 

--- a/lotsqrl/scenes/game.py
+++ b/lotsqrl/scenes/game.py
@@ -21,7 +21,7 @@ class GameScene(object):
         terminal.printf(0, screen_height - 1, "-" * screen_width)
         y_offset = top_gui_height + game_area_height + 3
 
-        messages = self.game.messages
+        messages = self.game.messaging.messages
         message_log_height = screen_info.message_log_height - 4
         for i, message in enumerate(messages[-message_log_height::]):
             terminal.printf(1, y_offset + i, message)

--- a/lotsqrl/selectors/base.py
+++ b/lotsqrl/selectors/base.py
@@ -18,4 +18,4 @@ class Selector(object):
 
     def show_message(self, actor):
         if self.message:
-            actor.game.add_message(self.message, show_now=True)
+            actor.game.messaging.add_system_message(self.message, show_now=True)

--- a/lotsqrl/selectors/directional.py
+++ b/lotsqrl/selectors/directional.py
@@ -9,7 +9,6 @@ class TouchDirectional(Selector):
         super().get(actor)
         offset = utils.get_directional_pos()
         if offset is None:
-            actor.game.add_message("Cancelled", show_now=True)
             return terminal.TK_INPUT_CANCELLED
 
         ox, oy = offset
@@ -28,7 +27,6 @@ class LineDirectional(Selector):
         super().get(actor)
         offset = utils.get_directional_pos()
         if offset is None:
-            actor.game.add_message("Cancelled", show_now=True)
             return terminal.TK_INPUT_CANCELLED
 
         ox, oy = offset
@@ -53,7 +51,6 @@ class GridPointDirectional(Selector):
         super().get(actor)
         offset = utils.get_directional_pos()
         if offset is None:
-            actor.game.add_message("Cancelled", show_now=True)
             return terminal.TK_INPUT_CANCELLED
 
         ox, oy = offset


### PR DESCRIPTION
Allows messages to be scoped which by default reduces the clutter in the combat log
It's possible to allow ALL messages by setting the msg_scope to 1 in the config.ini